### PR TITLE
bug issue

### DIFF
--- a/db/migrate/20250701085157_add__status_to_bookings.rb
+++ b/db/migrate/20250701085157_add__status_to_bookings.rb
@@ -1,5 +1,7 @@
 class AddStatusToBookings < ActiveRecord::Migration[7.1]
   def change
-    add_column :bookings, :status, :integer, null: false, default: 0
+    unless column_exists?(:bookings, :status)
+      add_column :bookings, :status, :integer, null: false, default: 0
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_01_102623) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_02_191304) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
I noticed that the add_status_to_bookings migration was causing a PG::DuplicateColumn error during db:migrate, because the status column already exists in the schema.

To prevent this error (especially when running migrations on fresh setups), I added a column_exists? check in the migration. Now the column will only be added if it doesn't already exist.

I tested the fix locally and everything works smoothly now 